### PR TITLE
update processor to incluse block receipt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ go.work.sum
 # env file
 .env
 
+cmd/main.go
 # Editor/IDE
 # .idea/
 # .vscode/

--- a/pkg/core/options.go
+++ b/pkg/core/options.go
@@ -1,5 +1,12 @@
 package core
 
+type FetchMode string
+
+const (
+	FetchModeLogs FetchMode = "logs" // Use eth_getlogs for efficiency
+	FetchModeReceipts FetchMode = "receipts" // Use eth_getBlockReceipts for reliability
+)
+
 type Options struct {
 	// BatchSize controls how many decoded events are buffered and written to sinks at once.
 	BatchSize int
@@ -31,4 +38,8 @@ type Options struct {
 	ReorgLookbackBlocks uint64
 	// Topics is the event for indexer to listen and get the log
 	Topics []string
+	// FetchMode determines which RPC method to use for fetching logs
+    // - "logs": Uses eth_getLogs (default, more efficient)
+    // - "receipts": Uses eth_getBlockReceipts (more reliable, higher bandwidth)
+	FetchMode FetchMode
 }

--- a/pkg/core/processor_test.go
+++ b/pkg/core/processor_test.go
@@ -72,6 +72,60 @@ func TestRunWithOneLog_Success(t *testing.T) {
 				},
 			})
 
+		case "eth_getBlockReceipts":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"jsonrpc": "2.0",
+				"id":      1,
+				"result": []map[string]any{
+					// Receipt 1: Transaction with Transfer event log
+					{
+						"BlockHash":         "0xbh1",
+						"BlockNumber":       "0x1",
+						"ContractAddress":   nil,
+						"CumulativeGasUsed": "0x5208",
+						"EffectiveGasPrice": "0x3b9aca00",
+						"From":              "0xsender",
+						"GasUsed":           "0x5208",
+						"Logs": []map[string]any{
+							{
+								"Address":          "0xabc",
+								"Topics":           []any{"0xddf252ad"},
+								"Data":             "0x",
+								"BlockNumber":      "0x1",
+								"TransactionHash":  "0xth1",
+								"TransactionIndex": "0x0",
+								"BlockHash":        "0xbh1",
+								"LogIndex":         "0x0",
+								"Removed":          false,
+							},
+						},
+						"LogsBloom":        "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+						"Status":           "0x1",
+						"To":               "0xabc",
+						"TransactionHash":  "0xth1",
+						"TransactionIndex": "0x0",
+						"Type":             "0x2",
+					},
+					// Receipt 2: Transaction with no logs
+					{
+						"BlockHash":         "0xbh1",
+						"BlockNumber":       "0x1",
+						"ContractAddress":   nil,
+						"CumulativeGasUsed": "0xa410",
+						"EffectiveGasPrice": "0x3b9aca00",
+						"From":              "0xsender2",
+						"GasUsed":           "0x5208",
+						"Logs":              []map[string]any{},
+						"LogsBloom":         "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+						"Status":            "0x1",
+						"To":                "0xreceiver",
+						"TransactionHash":   "0xth2",
+						"TransactionIndex":  "0x1",
+						"Type":              "0x2",
+					},
+				},
+			})
+
 		default:
 			http.Error(w, "method no supported", http.StatusBadRequest)
 		}
@@ -90,6 +144,7 @@ func TestRunWithOneLog_Success(t *testing.T) {
 		StartBlock:         0,
 		Confimation:        0,
 		LogsBufferSize:     1024,
+		FetchMode: FetchModeReceipts,
 	}
 	processor := NewProcessor(rpc, &opts)
 	go func() { _ = processor.Run(ctx)}()

--- a/pkg/core/rpc.go
+++ b/pkg/core/rpc.go
@@ -12,4 +12,7 @@ type RPC interface {
 
 	// Fetch logs over a range with filter
 	GetLogs(ctx context.Context, filter Filter) ([]Log, error)
+
+	// Get block receipt for the current block number
+	GetBlockReceipts(ctx context.Context, blockNumber string) ([]Receipt, error)
 }

--- a/pkg/core/rpc_http_test.go
+++ b/pkg/core/rpc_http_test.go
@@ -204,3 +204,145 @@ func TestGetLogs_HTTPStatusNotOK(t *testing.T) {
 	_, err := rpc.GetLogs(ctx, Filter{})
 	assert.Error(t, err)
 }
+
+func TestGetBlockReceipts_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any {
+			"jsonrpc": "2.0",
+			"id":      1,
+			"result": []map[string]any{
+				// Receipt 1: Regular transaction with logs (e.g., ERC20 transfer)
+				{
+					"blockHash":         "0xblock123",
+					"blockNumber":       "0x1",
+					"contractAddress":   nil, // null for non-contract creation
+					"cumulativeGasUsed": "0x5208",
+					"effectiveGasPrice": "0x3b9aca00",
+					"from":              "0xsender123",
+					"gasUsed":           "0x5208",
+					"logs": []map[string]any{
+						{
+							"address":          "0xtoken123",
+							"topics":           []any{"0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"}, // Transfer event
+							"data":             "0x0000000000000000000000000000000000000000000000000de0b6b3a7640000",
+							"blockNumber":      "0x1",
+							"transactionHash":  "0xtx123",
+							"transactionIndex": "0x0",
+							"blockHash":        "0xblock123",
+							"logIndex":         "0x0",
+							"removed":          false,
+						},
+					},
+					"logsBloom":        "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+					"status":           "0x1", // success
+					"to":               "0xtoken123",
+					"transactionHash":  "0xtx123",
+					"transactionIndex": "0x0",
+					"type":             "0x2",
+				},
+				// Receipt 2: Contract creation
+				{
+					"blockHash":         "0xblock123",
+					"blockNumber":       "0x1",
+					"contractAddress":   "0xnewcontract456", // NOT null for contract creation
+					"cumulativeGasUsed": "0xa410",
+					"effectiveGasPrice": "0x3b9aca00",
+					"from":              "0xdeployer789",
+					"gasUsed":           "0x5208",
+					"logs":              []map[string]any{}, // No logs in this example
+					"logsBloom":         "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+					"status":            "0x1",
+					"to":                "", // empty for contract creation
+					"transactionHash":   "0xtx456",
+					"transactionIndex":  "0x1",
+					"type":              "0x2",
+				},
+				// Receipt 3: Failed transaction
+				{
+					"blockHash":         "0xblock123",
+					"blockNumber":       "0x1",
+					"contractAddress":   nil,
+					"cumulativeGasUsed": "0xf618",
+					"effectiveGasPrice": "0x3b9aca00",
+					"from":              "0xfailsender",
+					"gasUsed":           "0x5208",
+					"logs":              []map[string]any{}, // No logs because failed
+					"logsBloom":         "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+					"status":            "0x0", // failure
+					"to":                "0xreceiver",
+					"transactionHash":   "0xtxfail",
+					"transactionIndex":  "0x2",
+					"type":              "0x2",
+				},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	rpc := NewHTTPRPC(srv.URL, 0)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	receipts, err := rpc.GetBlockReceipts(ctx, "0x000")
+	assert.NoError(t, err)
+	assert.Len(t, receipts, 3)
+
+	// Verify first receipt (regular transaction with logs)
+	assert.Equal(t, "0xblock123", receipts[0].BlockHash)
+	assert.Equal(t, "0x1", receipts[0].BlockNumber)
+	assert.Nil(t, receipts[0].ContractAddress) // null for non-contract creation
+	assert.Equal(t, "0x1", receipts[0].Status)
+	assert.Len(t, receipts[0].Logs, 1)
+	assert.Equal(t, "0xtoken123", receipts[0].Logs[0].Address)
+
+	// Verify second receipt (contract creation)
+	assert.Equal(t, "0x1", receipts[1].Status)
+	assert.NotNil(t, receipts[1].ContractAddress)
+	assert.Equal(t, "0xnewcontract456", *receipts[1].ContractAddress)
+	assert.Len(t, receipts[1].Logs, 0)
+
+	// Verify third receipt (failed transaction)
+	assert.Equal(t, "0x0", receipts[2].Status) // failed
+	assert.Len(t, receipts[2].Logs, 0)
+}
+
+func TestGetBlockReceipts_HTTPError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"jsonrpc": "2.0",
+			"id":      1,
+			"error": map[string]any{
+				"code":    -32000,
+				"message": "block not found",
+			},
+		})
+	}))
+	defer srv.Close()
+	
+	rpc := NewHTTPRPC(srv.URL, 0)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	
+	receipts, err := rpc.GetBlockReceipts(ctx, "0x000")
+	assert.Error(t, err)
+	assert.Len(t, receipts, 0)
+}
+
+func TestGetBlockReceipts_EmptyBlock(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any {
+			"jsonrpc": "2.0",
+			"id":      1,
+			"result": []map[string]any {},
+		})
+	}))
+	defer srv.Close()
+
+	rpc := NewHTTPRPC(srv.URL, 0)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	
+	receipt, err := rpc.GetBlockReceipts(ctx, "0x000")
+	assert.NoError(t, err)
+	assert.Len(t, receipt, 0)
+}

--- a/pkg/core/types.go
+++ b/pkg/core/types.go
@@ -37,8 +37,36 @@ type Log struct {
 	Removed bool `json:"removed,omitempty"`
 }
 
-type Event struct {
-
+type Receipt struct {
+	// The hash of the block. null when pending
+	BlockHash string `json:"blockHash"`
+	// The block number
+	BlockNumber string `json:"blockNumber"`
+	// The contract address created if the transaction was a contract creation, otherwise null
+	// Since contract address is  nullable, turn it into pointer to represent it
+	ContractAddress *string `json:"contractAddress,omitempty"`
+	// The total amount of gas used when this transaction was executed in the block
+	CumulativeGasUsed string `json:"cumulativeGasUsed"`
+	// The actual value per gas deducted from the sender account
+	EffectiveGasPrice string `json:"effectiveGasPrice"`
+	// The address of the sender
+	From string `json:"from"`
+	// The amount of gas used by this specific transaction alone
+	GasUsed string `json:"gasUsed"`
+	// An array of log objects that generated this transaction
+	Logs []Log `json:"logs"`
+	// The bloom filter for light clients to quickly retrieve related logs
+	LogsBloom string `json:"logsBloom"`
+	// It is either 1 (success) or 0 (failure) encoded as a hexadecimal
+	Status string `json:"status"`
+	// The address of the receiver. null when it's a contract creation transaction
+	To string `json:"to"`
+	// The hash of the transaction
+	TransactionHash string `json:"transactionHash"`
+	// An index of the transaction in the block
+	TransactionIndex string `json:"transactionIndex"`
+	// The value type
+	Type string `json:"type"`
 }
 
 type Filter struct {


### PR DESCRIPTION
# Summary
Processor now have option to fetch logs from block receipt for reliability instead of from eth_getlogs.

# Changes
pkg/core/processor.go
pkg/core/processor_test.go
pkg/core/http_rpc.go
pkg/core/http_rpc_test.go
pkg/core/types.go
pkg/core/options.go

# Related Issues
Closes #14 